### PR TITLE
[TASK] Refresh Gitbook doc planning

### DIFF
--- a/.codex/tasks/2f33f6ca-gitbook-overview.md
+++ b/.codex/tasks/2f33f6ca-gitbook-overview.md
@@ -1,0 +1,43 @@
+# Task: Draft Gitbook-friendly MetaHash overview & auction flow explainer
+
+> **Auditor Note (2024-05-23):** tightened source mapping for the role snapshots so miners/validators pull from their dedicated guides instead of overloading the README excerpt. Also called out the α transfer execution layer to keep “transfer → incentive assignment” traceable to both miner and validator code paths.
+
+## Preparation
+- Re-read the primary protocol references so we keep the “simplified” tone without drifting away from the actual implementation details:
+  - Core messaging and subsystem hooks from `README.md`, `docs/miner.md`, and `docs/validator.md` to keep every persona grounded in the latest guidance.【F:README.md†L19-L67】【F:docs/miner.md†L35-L136】【F:docs/validator.md†L16-L168】
+  - Validator execution pipeline and state transitions in the auction, clearing, settlement, and α-transfer modules so each auction milestone is backed by code.【F:metahash/validator/engines/auction.py†L1-L438】【F:metahash/validator/engines/clearing.py†L1-L349】【F:metahash/validator/engines/settlement.py†L1-L189】【F:metahash/validator/alpha_transfers.py†L1-L200】【F:neurons/validator.py†L1-L205】
+  - Miner-side payment duties and wallet automation to explain how α transfers are initiated and reconciled.【F:neurons/miner.py†L169-L320】
+- Skim the latest MetaHash subnet announcements (start with <https://x.com/MetaHashSn73/status/1972740673368727600>) so messaging stays consistent with public updates. If you cannot retrieve the full post, log the missing context in your task notes and highlight it in the document’s TODO section for future editors to incorporate once feedback arrives.
+
+## Goal
+Create a concise, Gitbook-ready explainer that introduces MetaHash (Subnet 73) to new readers and walks through the end-to-end auction lifecycle (auction start → bid submission → validator clearing → payment window → α transfer execution → settlement/incentive assignment). The document should be easy to skim, written in accessible language, and grounded in the actual code paths so technical readers can trust it while still feeling like a simplified guide for non-experts.
+
+## Scope & Requirements
+- **File location**: add a new markdown page under `docs/gitbook/overview.md` (create the folder if needed).
+- **Structure**: use Gitbook-friendly formatting (`#` headings, bullet lists, callouts/quotes, and optional tables). Provide:
+  - A short executive summary answering “What is MetaHash?” in simplified language before layering in protocol specifics.
+  - Role-based snapshots (dTAO holders, miners, validators, subnet owners) explaining how each benefits, drawing from the overview plus the miner/validator field guides so every audience segment has code-backed context.【F:README.md†L19-L44】【F:docs/miner.md†L35-L118】【F:docs/validator.md†L16-L136】
+  - A step-by-step auction flow section that mirrors the validator pipeline: auction start broadcast, bid validation (`AuctionEngine`), clearing (`ClearingEngine`), payment windows/invoices (`WinSynapse`), **α transfer execution** (miner payment scheduling + validator-side scanning), and settlement & weight updates (`SettlementEngine`). Highlight where commitments/IPFS fit in.【F:neurons/validator.py†L1-L205】【F:metahash/validator/engines/auction.py†L1-L438】【F:metahash/validator/engines/clearing.py†L1-L349】【F:metahash/validator/engines/settlement.py†L1-L189】【F:metahash/validator/alpha_transfers.py†L1-L200】【F:neurons/miner.py†L169-L320】
+  - A diagram-friendly outline or numbered checklist that downstream editors can easily convert into visuals.
+- **Clarity**: translate protocol terms (e.g., α planck, μTAO, reputation caps) into plain language while linking back to the specific modules/constants (`metahash/config.py`, `metahash/protocol.py`). Include short glossary bullets for recurring jargon.【F:metahash/config.py†L1-L111】【F:metahash/protocol.py†L1-L74】
+- **Cross-links**: add relative links to existing guides (`docs/miner.md`, `docs/validator.md`) where readers can dive deeper.
+- **Alignment**: explicitly confirm that the overview covers the four phases the team requested (auction start, bids, transfer/settlement, incentive assignment) and call out any assumptions that need future validation.
+- **Feedback loop**: dedicate a short “How to iterate” subsection that tells future editors where to capture crowd feedback (e.g., Gitbook comments, Discord threads) so the simplified overview remains easy to update.
+
+## Working Checklist (keep in the PR description)
+1. [ ] Draft high-level summary (“What is MetaHash?”) in simplified language referencing concrete modules/constants for validation.
+2. [ ] Complete persona snapshots for dTAO holders, miners, validators, and subnet owners with clear links back to their source files.
+3. [ ] Walk through the entire auction lifecycle with subsections that align to auction start → bids → clearing → payment window → α transfer execution → settlement/incentive assignment.
+4. [ ] Add inline TODOs for any messaging gaps discovered while reviewing the live announcements or community feedback threads so later editors can resolve them quickly.
+5. [ ] Run `markdownlint` (or `uv run python -m markdown_it` preview) locally to ensure Gitbook-friendly formatting and no trailing whitespace.
+6. [ ] Note any open questions or assumptions directly in the document for future editors.
+
+## Deliverables
+- `docs/gitbook/overview.md` containing the new explainer, written in an inviting but accurate tone.
+- Any supporting assets (e.g., temporary diagrams) can be referenced but do **not** embed binary files yet; just leave TODO callouts.
+
+## Acceptance Criteria
+- Markdown renders cleanly in Gitbook (no raw HTML required).
+- Every major protocol phase cites the source module(s) or docs so maintainers can verify facts quickly.
+- Terminology is consistent with the repo (e.g., “Win invoice”, “α transfers”, “budget burn to UID 0”).
+- Document clearly flags any open questions or assumptions so future editors can validate messaging before publishing.

--- a/.codex/tasks/5d8a8a90-gitbook-faq.md
+++ b/.codex/tasks/5d8a8a90-gitbook-faq.md
@@ -1,0 +1,49 @@
+# Task: Build living MetaHash FAQ page for Gitbook
+
+> **Auditor Note (2024-05-23):** added explicit α-transfer source coverage so the FAQ can quote both miner payment behavior and validator-side enforcement when answering the “transfer” phase questions.
+
+## Preparation
+- Skim the same core sources as the overview task so terminology, constants, and tone stay aligned between the two Gitbook pages:
+  - Baseline messaging and participant responsibilities in `README.md`, `docs/miner.md`, and `docs/validator.md`. Keep notes on any discrepancies or stale references for future follow-up tasks.【F:README.md†L13-L67】【F:docs/miner.md†L1-L136】【F:docs/validator.md†L1-L168】
+  - Auction lifecycle implementation (auction → bids → clearing → payment windows → α transfers → settlement/incentive assignment) in the validator engines and shared neuron helpers.【F:neurons/validator.py†L1-L205】【F:metahash/validator/engines/auction.py†L1-L438】【F:metahash/validator/engines/clearing.py†L1-L349】【F:metahash/validator/engines/settlement.py†L1-L189】【F:metahash/validator/alpha_transfers.py†L1-L200】
+  - Miner-side payment automation to anchor FAQs about invoices, α transfer proofs, and error handling.【F:neurons/miner.py†L1-L320】
+  - Config toggles that readers frequently ask about (strict settlement mode, subnet limits, testing utilities).【F:metahash/config.py†L1-L147】
+- Cross-check the latest subnet announcements (begin with <https://x.com/MetaHashSn73/status/1972740673368727600>) so FAQ answers stay aligned with public messaging. If you cannot retrieve everything from the live thread, flag the missing details in a TODO block so future contributors can integrate feedback once community members supply it.
+
+## Goal
+Produce a modular FAQ document that we can keep updating as community feedback arrives. The FAQ should answer core onboarding questions, clarify edge cases from the auction/settlement code, and surface operational guardrails for miners and validators.
+
+## Scope & Requirements
+- **File location**: create `docs/gitbook/faq.md` beside the new overview page.
+- **Audience**: newcomers (dTAO holders, miners, validators) plus technically curious readers. Keep answers concise with expandable sections (use Gitbook-friendly headings like `### Question` + bullet answers).
+- **Content sources**:
+  - Role/value summaries in `README.md` and `docs/miner.md` / `docs/validator.md` for baseline messaging.【F:README.md†L13-L57】【F:docs/miner.md†L1-L89】【F:docs/validator.md†L1-L126】
+  - Auction + settlement behaviors from validator engines to explain timing, payment windows, burns, incentive assignment, and reputation caps.【F:neurons/validator.py†L1-L205】【F:metahash/validator/engines/auction.py†L1-L438】【F:metahash/validator/engines/clearing.py†L1-L349】【F:metahash/validator/engines/settlement.py†L1-L189】
+  - Miner payment orchestration and validator α-transfer scanning so “transfer” answers cite the exact enforcement hooks.【F:neurons/miner.py†L169-L215】【F:metahash/validator/alpha_transfers.py†L1-L200】
+  - Configuration switches that power FAQs about TESTING mode, strict per-subnet enforcement, budget sizing, etc.【F:metahash/config.py†L1-L147】
+  - Wallet/payment handling from the miner implementation for user-facing troubleshooting.【F:neurons/miner.py†L1-L320】
+- **Sections to cover (add others if useful):**
+  1. “Quick facts” — What MetaHash does, supported assets, where data is published.
+  2. “Auction & Bidding” — Who can bid, how discounts work, why bids may be rejected.
+  3. “Payments & Settlement” — When invoices arrive, paying per-subnet, burns to UID 0, impact of late/missing payments, and how validator scanners detect α transfers.
+  4. “Validator Operations” — Master validator requirements, commitment publishing rules, IPFS expectations.
+  5. “Safety & Troubleshooting” — Treasury whitelists, jail conditions, and guidance on where to seek clarified messaging before referencing external announcements.
+- **Linking & maintainability**: cross-reference the overview page for deep dives and leave clearly marked TODOs where additional community Q&A should be added.
+- **Style**: use conversational questions (“How do I know my payment counted?”) with answers that point to specific constants or modules when relevant.
+
+## Deliverables
+- `docs/gitbook/faq.md` with organized sections, ready for Gitbook import.
+- Inline TODO comments or callouts identifying where future feedback should be merged (e.g., `> TODO: add validator rewards example once data available`).
+
+## Acceptance Criteria
+- All claims cite or link to a verifiable source within the repo.
+- FAQ addresses both high-level understanding and practical operational questions (payments, reputation caps, strict settlement policy).
+- FAQ explicitly anchors answers around the four requested phases (auction start, bids, transfer/settlement, incentive assignment) so contributors can verify coverage quickly.
+- Formatting avoids raw HTML; rely on Gitbook-friendly Markdown only.
+
+## Working Checklist (keep in the PR description)
+1. [ ] Capture at least three “Quick facts” entries that summarize MetaHash in simplified language while linking to underlying modules/constants.
+2. [ ] Write FAQ entries for each phase: auction start, bids/clearing, α transfers/payments, settlement/incentive assignment, and ensure each cites the appropriate validator/miner modules.
+3. [ ] Include maintenance guidance (e.g., `> TODO` blocks) wherever feedback from the community or live announcements is still pending so the FAQ stays easy to update collectively.
+4. [ ] Validate Markdown structure with `markdownlint` or a Gitbook preview to confirm collapsible sections/headings render as expected.
+5. [ ] Document any unresolved questions or items needing upstream clarification directly in the FAQ so subsequent editors can follow up quickly.


### PR DESCRIPTION
## Summary
- remove outdated cached MetaHash subnet announcement artifacts and the prior audit summary so tasks no longer rely on stale references
- update the Gitbook overview task to point contributors at the live announcement, add a feedback-loop subsection, and keep coverage of the four auction phases explicit
- refresh the Gitbook FAQ task to align messaging guidance with live announcements and reinforce collaborative maintenance hooks

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc858cfb10832c88b46b52a8708cce